### PR TITLE
refactor: migrate to LspPlugin

### DIFF
--- a/LSP-some-sass.sublime-settings
+++ b/LSP-some-sass.sublime-settings
@@ -145,6 +145,11 @@
 		"somesass.sass.workspaceSymbol.enabled": true,
 		"somesass.sass.customData": []
 	},
+	// The path to the server binary used to start the language server.
+	// Use `auto` for the package to manage (install/update) the server automatically.
+	// NOTE: Change this instead of directly updating `command` - the `${server_path}` variable is dynamically resolved based on this setting.
+	// WARNING: Override at your own risk - using a custom binary can cause compatibility issues with server settings.
+	"server_path": "auto",
 	"command": ["${node_bin}", "${server_path}", "--stdio"],
 	"selector": "source.scss",
 	"priority_selector": "source.scss",

--- a/plugin.py
+++ b/plugin.py
@@ -1,79 +1,72 @@
 from __future__ import annotations
 
 from .utils import get_eol
-from LSP.plugin import Session, apply_text_edits
+from functools import partial
+from LSP.plugin import LspPlugin, OnPreStartContext, Promise, apply_text_edits, command_handler
 from LSP.plugin.core.views import position_to_offset
-from LSP.protocol import DocumentUri, ExecuteCommandParams, Position, TextEdit
-from lsp_utils import NpmClientHandler
-from typing import Callable, Tuple, cast
-import os
+from LSP.protocol import DocumentUri, LSPAny, Position, TextEdit
+from lsp_utils import NodeManager
+from pathlib import Path
+from sublime_lib import ResourcePath
+from typing import Tuple, cast
+from typing_extensions import override
 import sublime
 
 ApplyExtractCodeActionArguments = Tuple[DocumentUri, int, TextEdit]
 
 
 def plugin_loaded():
-    LspSassPlugin.setup()
+    LspSassPlugin.register()
 
 
 def plugin_unloaded():
-    LspSassPlugin.cleanup()
+    LspSassPlugin.unregister()
 
 
-class LspSassPlugin(NpmClientHandler):
-    package_name = str(__package__)
-    server_directory = 'language-server'
-    server_binary_path = os.path.join(server_directory, 'node_modules', 'some-sass-language-server', 'bin', 'some-sass-language-server')
+class LspSassPlugin(LspPlugin):
 
     @classmethod
-    def required_node_version(cls) -> str:
-        return '>=20'
+    @override
+    def on_pre_start_async(cls, context: OnPreStartContext) -> None:
+        package_name = cls.plugin_storage_path.name
+        NodeManager.on_pre_start_async(
+            context,
+            cls.plugin_storage_path,
+            ResourcePath('Packages', package_name, 'language-server'),
+            Path('node_modules', 'some-sass-language-server', 'bin', 'some-sass-language-server'),
+            node_version_requirement='>=20',
+        )
 
-    def on_pre_server_command(self, command: ExecuteCommandParams, done_callback: Callable[[], None]) -> bool:
-        session = self.weaksession()
-        if not session:
-            return False
-        if command['command'] == '_somesass.applyExtractCodeAction':
-            if 'arguments' in command:
-                arguments = cast(ApplyExtractCodeActionArguments, command['arguments'])
-                self._handle_apply_extract_code_action(arguments, session, done_callback)
-            else:
-                sublime.status_message('No arguments provided to applyExtractCodeAction command. Ignoring.')
-            return True
-        return False
+    @command_handler('_somesass.applyExtractCodeAction')
+    def on_apply_extract_code_action_command(self, arguments: list[LSPAny] | None) -> Promise[LSPAny]:
+        if arguments and (session := self.weaksession()):
+            uri, document_version, text_edit = cast('ApplyExtractCodeActionArguments', arguments)
+            if session_buffer := session.get_session_buffer_for_uri_async(uri):
+                if document_version != session_buffer.last_synced_version:
+                    sublime.status_message('The document has changed since the extract edit was made. Please retry.')
+                    return Promise.resolve(None)
+                for session_view in session_buffer.session_views:
+                    view = session_view.view
 
-    def _handle_apply_extract_code_action(
-        self, arguments: ApplyExtractCodeActionArguments, session: Session, done_callback: Callable[[], None]
-    ) -> None:
-        uri, document_version, text_edit = arguments
-        session_buffer = session.get_session_buffer_for_uri_async(uri)
-        if not session_buffer:
-            done_callback()
-            return
-        if document_version != session_buffer.version:
-            sublime.status_message('The document has changed since the extract edit was made. Please retry.')
-            done_callback()
-            return
-        for session_view in session_buffer.session_views:
-            view = session_view.view
-            apply_text_edits(view, [text_edit], required_view_version=document_version)
-            def trigger_rename() -> None:
-                new_text = text_edit['newText']
-                lines = new_text.split(get_eol(new_text))
-                usage_keywords = ['_variable', '_function', '_mixin']
-                line_of_usage = lines[len(lines) - 1]
-                usage_keyword_positions = [line_of_usage.find(keyword) for keyword in usage_keywords]
-                position: Position = {
-                    'line': text_edit['range']['start']['line'] + len(lines) - 1,
-                    'character': max(usage_keyword_positions) + 1,
-                }
-                point = position_to_offset(position, view)
-                view.sel().clear()
-                view.sel().add(point)
-                view.run_command('lsp_symbol_rename', {'session_name': LspSassPlugin.name()})
-                done_callback()
-            # Trigger rename after a timeout to ensure didChange is sent to the server beforehand.
-            sublime.set_timeout(trigger_rename)
-            return
-        done_callback()
+                    def trigger_rename(view: sublime.View | None) -> None:
+                        if not view:
+                            return
+                        new_text = text_edit['newText']
+                        lines = new_text.split(get_eol(new_text))
+                        usage_keywords = ['_variable', '_function', '_mixin']
+                        line_of_usage = lines[len(lines) - 1]
+                        usage_keyword_positions = [line_of_usage.find(keyword) for keyword in usage_keywords]
+                        position: Position = {
+                            'line': text_edit['range']['start']['line'] + len(lines) - 1,
+                            'character': max(usage_keyword_positions) + 1,
+                        }
+                        point = position_to_offset(position, view)
+                        view.sel().clear()
+                        view.sel().add(point)
+                        view.run_command('lsp_symbol_rename', {'session_name': self.plugin_storage_path.name})
 
+                    return apply_text_edits(view, [text_edit], required_view_version=document_version) \
+                        .then(lambda view: sublime.set_timeout(partial(trigger_rename, view)))
+        else:
+            sublime.status_message('No arguments provided to applyExtractCodeAction command. Ignoring.')
+        return Promise.resolve(None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.pyright]
 pythonVersion = "3.8"
+typeCheckingMode = "standard"
 
 [tool.ruff]
 line-length = 120

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -10,6 +10,11 @@
           "definitions": {
             "PluginConfig": {
               "properties": {
+                "server_path": {
+                  "type": "string",
+                  "default": "auto",
+                  "markdownDescription": "The path to the server binary to use for starting the language server. Use `auto` for the package to manage (install/update) server automatically.\n\n> [!NOTE]\n> Change this instead of directly updating `command` - the `${server_path}` variable is dynamically resolved based on this setting.\n\n> [!WARNING]\n> Using custom binary could result in package settings not matching what server supports."
+                },
                 "settings": {
                   "additionalProperties": false,
                   "properties": {


### PR DESCRIPTION
Migrate to [LspPlugin API](https://lsp.sublimetext.io/migrating_to_lsp_plugin/). The `NpmClientHandler` is slated for removal.